### PR TITLE
설정페이지(메인, 개발자에게)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,13 @@ export default function RootLayout({
     return () => clearTimeout(timer);
   }, []);
 
-  const hidePaths = ["/login", "/login/first", "/signup", "/signup/complete"]; // 네비바 숨길 경로 배열
+  const hidePaths = [
+    "/login",
+    "/login/first",
+    "/signup",
+    "/signup/complete",
+    "/setting",
+  ]; // 네비바 숨길 경로 배열
   const shouldHide = hidePaths.includes(pathname);
   return (
     <html lang="en">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,14 +22,8 @@ export default function RootLayout({
     return () => clearTimeout(timer);
   }, []);
 
-  const hidePaths = [
-    "/login",
-    "/login/first",
-    "/signup",
-    "/signup/complete",
-    "/setting",
-  ]; // 네비바 숨길 경로 배열
-  const shouldHide = hidePaths.includes(pathname);
+  const hidePaths = ["/login", "/signup", "/setting"]; // 네비바 숨길 경로 배열
+  const shouldHide = hidePaths.some((path) => pathname.startsWith(path));
   return (
     <html lang="en">
       <body>

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -2,29 +2,15 @@
 
 import styled from "styled-components";
 import { theme } from "../styles/theme";
-import { IoChevronBack, IoChevronForward } from "react-icons/io5";
+import { IoChevronForward } from "react-icons/io5";
 import { useRouter } from "next/navigation";
+import SettingHeader from "@/components/settingHeader";
 
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
   max-width: 31rem;
-`;
-const Header = styled.div`
-  top: 0;
-  height: 4.75rem;
-  display: flex;
-  align-items: center;
-  padding: 1.5rem 1rem;
-  gap: 0.5rem;
-  background-color: ${theme.colors.secondary};
-  color: ${theme.colors.text};
-  font-family: Pretendard;
-  font-size: 1.25rem;
-  font-style: normal;
-  font-weight: 800;
-  line-height: normal;
 `;
 const ItemContainer = styled.div`
   display: flex;
@@ -60,10 +46,7 @@ export default function Setting() {
   };
   return (
     <Wrapper>
-      <Header>
-        <IoChevronBack fontSize="2rem" />
-        설정
-      </Header>
+      <SettingHeader />
       <ItemContainer>
         <Content onClick={() => handleClick("/setting/toDeveloper")}>
           <Items>개발자에게 하고싶은 말!</Items>

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -1,3 +1,105 @@
-export default function Home() {
-  return <div>설정 화면</div>;
+"use client";
+
+import styled from "styled-components";
+import { theme } from "../styles/theme";
+import { IoChevronBack, IoChevronForward } from "react-icons/io5";
+import { useRouter } from "next/navigation";
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 31rem;
+`;
+const Header = styled.div`
+  top: 0;
+  height: 4.75rem;
+  display: flex;
+  align-items: center;
+  padding: 1.5rem 1rem;
+  gap: 0.5rem;
+  background-color: ${theme.colors.secondary};
+  color: ${theme.colors.text};
+  font-family: Pretendard;
+  font-size: 1.25rem;
+  font-style: normal;
+  font-weight: 800;
+  line-height: normal;
+`;
+const ItemContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+`;
+const Content = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  height: 4.8rem;
+  border-bottom: 1px solid ${theme.colors.warning};
+`;
+const Items = styled.div`
+  padding: 1rem;
+  color: ${theme.colors.text};
+  font-family: Pretendard;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+`;
+const Icon = styled.div`
+  font-size: 1.5rem;
+  color: ${theme.colors.secondary};
+`;
+
+export default function Setting() {
+  const router = useRouter();
+  const handleClick = (url: string) => {
+    router.push(url);
+  };
+  return (
+    <Wrapper>
+      <Header>
+        <IoChevronBack fontSize="2rem" />
+        설정
+      </Header>
+      <ItemContainer>
+        <Content onClick={() => handleClick("/setting/toDeveloper")}>
+          <Items>개발자에게 하고싶은 말!</Items>
+          <Icon>
+            <IoChevronForward />
+          </Icon>
+        </Content>
+
+        <Content onClick={() => handleClick("/setting/curriculum")}>
+          <Items>학부 과목 트랙&이수체계도</Items>
+          <Icon>
+            <IoChevronForward />
+          </Icon>
+        </Content>
+
+        <Content onClick={() => handleClick("/setting/applyRating")}>
+          <Items>학생회 등급신청</Items>
+          <Icon>
+            <IoChevronForward />
+          </Icon>
+        </Content>
+
+        <Content onClick={() => handleClick("/setting/list")}>
+          <Items>학생회 명단</Items>
+          <Icon>
+            <IoChevronForward />
+          </Icon>
+        </Content>
+
+        <Content>
+          <Items>로그아웃</Items>
+          <Icon>
+            <IoChevronForward />
+          </Icon>
+        </Content>
+      </ItemContainer>
+    </Wrapper>
+  );
 }

--- a/src/app/setting/toDeveloper/page.tsx
+++ b/src/app/setting/toDeveloper/page.tsx
@@ -1,11 +1,115 @@
 "use client";
+import { theme } from "@/app/styles/theme";
 import SettingHeader from "@/components/settingHeader";
+import { useState } from "react";
+import { BiMessageSquareEdit } from "react-icons/bi";
+import { FaPlusCircle } from "react-icons/fa";
+import styled from "styled-components";
 
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 31rem;
+`;
+const Container = styled.div`
+  padding: 1.6rem;
+`;
+const TitleContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+const Title = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-right: 3.5rem;
+  color: ${theme.colors.text};
+  font-family: Pretendard;
+  font-size: 1.25rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  letter-spacing: -0.0375rem;
+`;
+const Highlight = styled.div`
+  color: ${theme.colors.primary};
+  font-family: Pretendard;
+  font-size: 1.25rem;
+  font-style: normal;
+  font-weight: 800;
+  line-height: normal;
+`;
+const InputContainer = styled.div`
+  width: 95%;
+  display: flex;
+  flex-direction: row;
+  margin: 2.13rem 0;
+  position: relative;
+`;
+const Icon = styled.div`
+  width: 1.25rem;
+  height: 1.25rem;
+  position: relative;
+`;
+
+interface inputProps {
+  hasText: boolean;
+}
+const Input = styled.textarea<inputProps>`
+  width: 100%;
+  height: 5.25rem;
+  border-radius: 0rem 0.625rem 0.625rem 0.625rem;
+  border: 1px solid #3a3a3a;
+  background: #fff;
+  padding: 0.56rem;
+  margin-top: 1rem;
+  color: ${(props) =>
+    props.hasText ? theme.colors.text : theme.colors.mutedText};
+  font-family: Pretendard;
+  font-size: 0.625rem;
+  font-weight: 300;
+  resize: none;
+  position: relative;
+`;
+const CharCount = styled.div`
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.56rem;
+  color: ${theme.colors.text};
+  font-size: 0.375rem;
+  font-style: normal;
+  font-weight: 300;
+`;
 export default function ToDeveloper() {
+  const [text, setText] = useState("");
+
   return (
-    <>
+    <Wrapper>
       <SettingHeader />
-      <div>개발자에게</div>
-    </>
+      <Container>
+        <Title>To. 개발자</Title>
+        <TitleContent>
+          <Title>
+            <Highlight>이런 기능</Highlight>있었으면 좋겠어요!
+          </Title>
+          <BiMessageSquareEdit fontSize="2rem" />
+        </TitleContent>
+
+        <InputContainer>
+          <Icon>
+            <FaPlusCircle />
+          </Icon>
+          <Input
+            value={text}
+            onChange={(e) => setText(e.target.value.slice(0, 100))}
+            hasText={text.length > 0}
+            placeholder="개발자에게 원하는 점을 적어주세요"
+          />
+          <CharCount>{text.length}/100</CharCount>
+        </InputContainer>
+      </Container>
+    </Wrapper>
   );
 }

--- a/src/app/setting/toDeveloper/page.tsx
+++ b/src/app/setting/toDeveloper/page.tsx
@@ -3,7 +3,7 @@ import { theme } from "@/app/styles/theme";
 import SettingHeader from "@/components/settingHeader";
 import { useState } from "react";
 import { BiMessageSquareEdit } from "react-icons/bi";
-import { FaPlusCircle } from "react-icons/fa";
+import { FaCheckCircle, FaPlusCircle } from "react-icons/fa";
 import styled from "styled-components";
 
 const Wrapper = styled.div`
@@ -99,7 +99,11 @@ export default function ToDeveloper() {
 
         <InputContainer>
           <Icon>
-            <FaPlusCircle />
+            {text.length > 0 ? (
+              <FaCheckCircle color="#4CAF50" />
+            ) : (
+              <FaPlusCircle />
+            )}
           </Icon>
           <Input
             value={text}

--- a/src/app/setting/toDeveloper/page.tsx
+++ b/src/app/setting/toDeveloper/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 import { theme } from "@/app/styles/theme";
 import SettingHeader from "@/components/settingHeader";
+import SettingInput from "@/components/settingInput";
 import { useState } from "react";
 import { BiMessageSquareEdit } from "react-icons/bi";
-import { FaCheckCircle, FaPlusCircle } from "react-icons/fa";
 import styled from "styled-components";
 
 const Wrapper = styled.div`
@@ -41,50 +41,12 @@ const Highlight = styled.div`
   font-weight: 800;
   line-height: normal;
 `;
-const InputContainer = styled.div`
-  width: 95%;
-  display: flex;
-  flex-direction: row;
-  margin: 2.13rem 0;
-  position: relative;
-`;
-const Icon = styled.div`
-  width: 1.25rem;
-  height: 1.25rem;
-  position: relative;
-`;
 
-interface inputProps {
-  hasText: boolean;
-}
-const Input = styled.textarea<inputProps>`
-  width: 100%;
-  height: 5.25rem;
-  border-radius: 0rem 0.625rem 0.625rem 0.625rem;
-  border: 1px solid #3a3a3a;
-  background: #fff;
-  padding: 0.56rem;
-  margin-top: 1rem;
-  color: ${(props) =>
-    props.hasText ? theme.colors.text : theme.colors.mutedText};
-  font-family: Pretendard;
-  font-size: 0.625rem;
-  font-weight: 300;
-  resize: none;
-  position: relative;
-`;
-const CharCount = styled.div`
-  position: absolute;
-  bottom: 0.5rem;
-  right: 0.56rem;
-  color: ${theme.colors.text};
-  font-size: 0.375rem;
-  font-style: normal;
-  font-weight: 300;
-`;
 export default function ToDeveloper() {
-  const [text, setText] = useState("");
-
+  const [inputs, setInputs] = useState([{ text: "" }]);
+  const addInputContainer = () => {
+    setInputs([...inputs, { text: "" }]);
+  };
   return (
     <Wrapper>
       <SettingHeader />
@@ -94,25 +56,9 @@ export default function ToDeveloper() {
           <Title>
             <Highlight>이런 기능</Highlight>있었으면 좋겠어요!
           </Title>
-          <BiMessageSquareEdit fontSize="2rem" />
+          <BiMessageSquareEdit fontSize="2rem" onClick={addInputContainer} />
         </TitleContent>
-
-        <InputContainer>
-          <Icon>
-            {text.length > 0 ? (
-              <FaCheckCircle color="#4CAF50" />
-            ) : (
-              <FaPlusCircle />
-            )}
-          </Icon>
-          <Input
-            value={text}
-            onChange={(e) => setText(e.target.value.slice(0, 100))}
-            hasText={text.length > 0}
-            placeholder="개발자에게 원하는 점을 적어주세요"
-          />
-          <CharCount>{text.length}/100</CharCount>
-        </InputContainer>
+        <SettingInput />
       </Container>
     </Wrapper>
   );

--- a/src/app/setting/toDeveloper/page.tsx
+++ b/src/app/setting/toDeveloper/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import SettingHeader from "@/components/settingHeader";
+
+export default function ToDeveloper() {
+  return (
+    <>
+      <SettingHeader />
+      <div>개발자에게</div>
+    </>
+  );
+}

--- a/src/components/settingHeader.tsx
+++ b/src/components/settingHeader.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import styled from "styled-components";
+import { IoChevronBack } from "react-icons/io5";
+import { theme } from "@/app/styles/theme";
+
+const Header = styled.div`
+  top: 0;
+  height: 4.75rem;
+  display: flex;
+  align-items: center;
+  padding: 1.5rem 1rem;
+  gap: 0.5rem;
+  background-color: ${theme.colors.secondary};
+  color: ${theme.colors.text};
+  font-family: Pretendard;
+  font-size: 1.25rem;
+  font-style: normal;
+  font-weight: 800;
+  line-height: normal;
+`;
+export default function SettingHeader() {
+  return (
+    <Header>
+      <IoChevronBack fontSize="2rem" />
+      설정
+    </Header>
+  );
+}

--- a/src/components/settingInput.tsx
+++ b/src/components/settingInput.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { theme } from "@/app/styles/theme";
+import { useState } from "react";
+import { FaCheckCircle, FaPlusCircle } from "react-icons/fa";
+import styled from "styled-components";
+
+const InputContainer = styled.div`
+  width: 95%;
+  display: flex;
+  flex-direction: row;
+  margin: 2.13rem 0;
+  position: relative;
+`;
+const Icon = styled.div`
+  width: 1.25rem;
+  height: 1.25rem;
+  position: relative;
+`;
+
+interface inputProps {
+  hasText: boolean;
+}
+const Input = styled.textarea<inputProps>`
+  width: 100%;
+  height: 5.25rem;
+  border-radius: 0rem 0.625rem 0.625rem 0.625rem;
+  border: 1px solid #3a3a3a;
+  background: #fff;
+  padding: 0.56rem;
+  margin-top: 1rem;
+  color: ${(props) =>
+    props.hasText ? theme.colors.text : theme.colors.mutedText};
+  font-family: Pretendard;
+  font-size: 0.625rem;
+  font-weight: 300;
+  resize: none;
+  position: relative;
+`;
+const CharCount = styled.div`
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.56rem;
+  color: ${theme.colors.text};
+  font-size: 0.375rem;
+  font-style: normal;
+  font-weight: 300;
+`;
+export default function SettingInput() {
+  const [text, setText] = useState("");
+  return (
+    <InputContainer>
+      <Icon>
+        {text.length > 0 ? <FaCheckCircle color="#4CAF50" /> : <FaPlusCircle />}
+      </Icon>
+      <Input
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, 100))}
+        hasText={text.length > 0}
+        placeholder="개발자에게 원하는 점을 적어주세요"
+      />
+      <CharCount>{text.length}/100</CharCount>
+    </InputContainer>
+  );
+}

--- a/src/components/settingInput.tsx
+++ b/src/components/settingInput.tsx
@@ -20,7 +20,9 @@ const Icon = styled.div`
 interface inputProps {
   hasText: boolean;
 }
-const Input = styled.textarea<inputProps>`
+const Input = styled.textarea.withConfig({
+  shouldForwardProp: (props) => props !== "hasText",
+})<inputProps>`
   width: 100%;
   height: 5.25rem;
   border-radius: 0rem 0.625rem 0.625rem 0.625rem;


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #번호

## 📝 작업 내용

> 설정 메인 페이지, 하고싶은말 페이지

- 설정 메인 페이지
- 설정 페이지들 라우팅 분리
- "개발자에게 ~" 페이지 컴포넌트 처리
- 입력시 아이콘 변경

설정 메인 페이지
<img width="200px" src="https://github.com/user-attachments/assets/18f9704f-4c73-41d4-8d9e-21982100b57c" />

개발자에게 하고싶은말
<img width="200px" src="https://github.com/user-attachments/assets/3e2feba6-2232-4df0-9fd3-ae814e010b0d" />

내용 입력시
<img width="200px" src="https://github.com/user-attachments/assets/d42ad383-ac59-4e82-99ab-4c53ebd09161"/>

## 📝 예외 처리

상태관리로 "개발자에게" 파트 수정 예정

