### PR TITLE
feat: 로그인 상태에 따른 페이지 리다이렉팅

### DIFF
--- a/src/apis/developerQuestion.ts
+++ b/src/apis/developerQuestion.ts
@@ -9,7 +9,10 @@ export const postQuestion = async (
   data: DevQuestionRequest
 ): Promise<{ id: number; content: string }> => {
   try {
-    const response = await instance.post("/api/v1/developer/questions", data);
+    const response = await instance.post(
+      "/api/v1/developer/questions/my",
+      data
+    );
     return response.data;
   } catch (error) {
     throw error;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
   const pathname = usePathname();
   const [loading, setLoading] = useState(true);
   useEffect(() => {
-    const timer = setTimeout(() => setLoading(false), 3000);
+    const timer = setTimeout(() => setLoading(false), 300);
     return () => clearTimeout(timer);
   }, []);
 
@@ -30,15 +30,15 @@ export default function RootLayout({
         <GlobalStyle />
         <StyledComponentsRegistry>
           <ThemeProviderWrapper>
-            {/* {loading ? (
+            {loading ? (
               <Loading />
-            ) : ( */}
-            <Container>
-              {!shouldHide && <HeaderNavbar />}
-              <MobileWapper>{children}</MobileWapper>
-              {!shouldHide && <BottomNavbar />}
-            </Container>
-            {/* )} */}
+            ) : (
+              <Container>
+                {!shouldHide && <HeaderNavbar />}
+                <MobileWapper>{children}</MobileWapper>
+                {!shouldHide && <BottomNavbar />}
+              </Container>
+            )}
           </ThemeProviderWrapper>
         </StyledComponentsRegistry>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,24 @@
-import { redirect } from "next/navigation";
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
-export default function Notice() {
-  redirect("/notice");
+export default function RedirectPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    setTimeout(() => {
+      const token = document.cookie
+        .split("; ")
+        .find((row) => row.startsWith("AccessToken"))
+        ?.split("=")[1];
+
+      if (!token) {
+        router.push("/login"); // 로그인 안 되어 있으면 로그인 페이지로 이동
+      } else {
+        router.push("/notice"); // 로그인 상태면 공지 페이지로 이동
+      }
+    }, 100); // 브라우저가 쿠키 업데이트할 시간을 확보
+  }, [router]);
+
+  return null;
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #56 

## 📝 작업 내용

토큰 상태에 따라 로그인 페이지/공지 페이지로 이동

## 📝 예외 처리

클라이언트 화면에서의 리다이렉팅은 `useRouter()`의 `router.push()` 사용
`redirect()`는 서버 컴포넌트에서만 사용가능함