### PR TITLE
fix: MY 페이지에서 답변완료인 경우, 공유상태만 수정 가능하게 되도록 오류 수정

### DIFF
--- a/src/apis/question.ts
+++ b/src/apis/question.ts
@@ -59,12 +59,14 @@ export const deleteQuestion = async (
 //MY - 내가 쓴글 내가쓴글 답변완료일 경우, 확인 가능
 export const putQuestion = async (
   majorQuestionId: number,
-  shared: boolean
+  shared: boolean,
+  title: string,
+  content: string
 ): Promise<void> => {
   try {
     const response = await instance.put(
       `/api/v1/major/questions/${majorQuestionId}`,
-      { shared }
+      { shared, title, content }
     );
     return response.data;
   } catch (error) {

--- a/src/app/my/writingCheck/check/page.tsx
+++ b/src/app/my/writingCheck/check/page.tsx
@@ -59,7 +59,12 @@ export default function Check() {
       return;
     }
     try {
-      await putQuestion(question.id, shared);
+      await putQuestion(
+        question.id,
+        shared,
+        question?.title,
+        question?.content
+      );
       alert("공유 상태가 업데이트되었습니다.");
       router.back();
     } catch (error) {


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #114

## 📝 작업 내용

MY 페이지에서 답변완료인 경우, 공유상태만 수정 가능하게 되도록 오류 수정