### PR TITLE
[QA&fix]과행사 공지글에서 사진 여러개 뜨도록 수정

### DIFF
--- a/src/app/notice/event/detail/page.tsx
+++ b/src/app/notice/event/detail/page.tsx
@@ -79,17 +79,18 @@ const WritingBtn = styled.div`
 const ImageContainer = styled.div`
   display: flex;
   position: relative;
-  width: 100%;
-  height: auto;
+  width: 600px; // 카드뉴스 사이즈에 맞춰 바꾸기
+  height: 400px; 
   justify-content: center;
   align-items: center;
+  overflow: hidden;
 `;
 
 const StyledImage = styled(Image)`
   border-radius: 0.5rem;
-  object-fit: cover;
-  max-width: 100%; /* 이미지가 컨테이너를 넘어가지 않도록 */
-  height: auto; /* 비율 유지 */
+  object-fit: contain; /* 비율 유지하면서 지정된 크기 안에 맞춤 */
+  width: 100%;
+  height: 100%;
 `;
 
 const EventText = styled.div`
@@ -105,6 +106,37 @@ const ButtonContainer = styled.div`
   display: flex;
   justify-content: center;
   margin: 1rem 0;
+`;
+const ImageSliderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  margin: auto;
+`;
+
+const SlideButton = styled.button`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: none;
+  padding: 10px 15px;
+  cursor: pointer;
+  font-size: 1rem;
+  border-radius: 50%;
+  z-index: 10;
+
+  &:first-child {
+    left: 10px;
+  }
+
+  &:last-child {
+    right: 10px;
+  }
 `;
 
 export default function EventDetail() {
@@ -124,7 +156,16 @@ export default function EventDetail() {
 
   const [dday, setDday] = useState<number | string>("");
   const [role, setRole] = useState<string | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
 
+  const handlePrev = () => {
+    setCurrentIndex((prev) => (prev === 0 ?(event.cardNewsImageUrls || []).length - 1 : prev - 1));
+  };
+  
+  const handleNext = () => {
+    setCurrentIndex((prev) =>  (prev === (event.cardNewsImageUrls || []).length - 1 ? 0 : prev + 1));
+  };
+  
   useEffect(() => {
     if (id) {
       inquireEvent(parseInt(id))
@@ -205,16 +246,21 @@ export default function EventDetail() {
           <FaPenToSquare />
         </WritingBtn>
         <CustomFormWrapper>
-          {event?.cardNewsImageUrls && event.cardNewsImageUrls.length > 0 && (
+        {event?.cardNewsImageUrls && event.cardNewsImageUrls.length > 0 && (
+          <ImageSliderContainer>
+            <SlideButton onClick={handlePrev}>〈</SlideButton> {/* 이전 버튼 */}
             <ImageContainer>
               <StyledImage
-                src={event.cardNewsImageUrls[0]}
-                alt="이벤트 이미지"
+                src={event.cardNewsImageUrls[currentIndex]}
+                alt={`이벤트 이미지 ${currentIndex + 1}`}
                 width={600}
                 height={400}
               />
             </ImageContainer>
-          )}
+            <SlideButton onClick={handleNext}>〉</SlideButton> {/* 다음 버튼 */}
+          </ImageSliderContainer>
+        )}
+
           <EventText>{event.notice}</EventText>
         </CustomFormWrapper>
         <ButtonContainer>

--- a/src/app/notice/event/detail/page.tsx
+++ b/src/app/notice/event/detail/page.tsx
@@ -200,7 +200,7 @@ export default function EventDetail() {
         if (daysRemaining < 0) {
           setDday("종료");
         } else if (daysRemaining === 0) {
-          setDday("D-Day");
+          setDday("D-day");
         } else {
           setDday(`D-${daysRemaining}`);
         }

--- a/src/app/notice/event/detail/page.tsx
+++ b/src/app/notice/event/detail/page.tsx
@@ -236,6 +236,7 @@ export default function EventDetail() {
           onClick={handleWriteClick}
           style={{
             visibility:
+            role === "ROLE_ADMIN" ||
               role === "ROLE_MAJOR_PRESIDENT" ||
               role === "ROLE_GRADUATE_STUDENT"
                 ? "visible"
@@ -248,7 +249,11 @@ export default function EventDetail() {
         <CustomFormWrapper>
         {event?.cardNewsImageUrls && event.cardNewsImageUrls.length > 0 && (
           <ImageSliderContainer>
-            <SlideButton onClick={handlePrev}>〈</SlideButton> {/* 이전 버튼 */}
+            {/* 이전 버튼 (이미지가 2장 이상일 때만 보이도록) */}
+            {event.cardNewsImageUrls.length > 1 && (
+              <SlideButton onClick={handlePrev}>〈</SlideButton>
+            )}
+
             <ImageContainer>
               <StyledImage
                 src={event.cardNewsImageUrls[currentIndex]}
@@ -257,9 +262,14 @@ export default function EventDetail() {
                 height={400}
               />
             </ImageContainer>
-            <SlideButton onClick={handleNext}>〉</SlideButton> {/* 다음 버튼 */}
+
+            {/* 다음 버튼 (이미지가 2장 이상일 때만 보이도록) */}
+            {event.cardNewsImageUrls.length > 1 && (
+              <SlideButton onClick={handleNext}>〉</SlideButton>
+            )}
           </ImageSliderContainer>
         )}
+
 
           <EventText>{event.notice}</EventText>
         </CustomFormWrapper>

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -143,10 +143,13 @@ export default function Notice() {
   const calculateDDay = (date: string) => {
     const eventDate = new Date(date);
     const today = new Date();
-    const diff = Math.ceil(
+    const diff = Math.floor(
       (eventDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
     );
-    return diff >= 0 ? `D-${diff}` : "종료됨";
+
+    if (diff===0) return "D-day";
+    if (diff<0) return "종료됨";
+    return `D-${diff}` ;
   };
 
   return (

--- a/src/app/setting/applyRating/page.tsx
+++ b/src/app/setting/applyRating/page.tsx
@@ -161,16 +161,27 @@ export default function ApplyRating() {
     // 로컬스토리지에서 memberData 가져오기
     const memberData = JSON.parse(localStorage.getItem("memberData") || "{}");
     if (memberData) {
-      setValues({
+      const initialValues = {
         name: memberData.name || "",
-        id: memberData.studentNumber || "",
+        id: memberData.studentNumber ? memberData.studentNumber.toString() : "",  // 학번을 문자열로 저장
         unit: memberData.major || "",
         position: memberData.position || "",
         role: memberData.role || "ROLE_STUDENT", // 기본값 설정
-      });
-      setSelectedRole(mapRoleToDisplay(memberData.role || "ROLE_STUDENT"));
+      };
+  
+      setValues(initialValues);
+      setSelectedRole(mapRoleToDisplay(initialValues.role));
+  
+      // 로컬스토리지 값에 맞춰 isFormValid 업데이트
+      setIsFormValid(
+        initialValues.name !== "" &&
+          initialValues.id !== "" &&
+          initialValues.id.length === 9 &&  // 학번 길이 검사
+          initialValues.unit !== "" &&
+          initialValues.position !== ""
+      );
     }
-  }, []);
+  }, []); 
   const handleRoleChange = (role: string) => {
     let roleMapping: string;
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #번호

## 📝 작업 내용

- 사진 여러개 뜨도록 수정
- 2개이상인 경우엔 화살표를 눌러서 넘길수 있도록 함 (사진이 하나인 경우는 화살표 안뜸)
- 과행사 날짜함수 수정
- 등급신청 안되던 문제 해결(숫자를 문자열로 못읽어서 생기던 문제)

## 💬 리뷰 요구사항(선택)
화살표 ui를 대충 해서 안예뻐요,, 바꿔주삼!
